### PR TITLE
Improve generator

### DIFF
--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -317,6 +317,8 @@ func (g *Generator) analyzeFields(rootPkg string, orig *spec.Message, fields []*
 					m.Depend(spec.DependTypeInterface, rootPkg)
 				} else if !recursive {
 					m.Depend(spec.DependTypeMessage, rootPkg)
+				} else {
+					return nil
 				}
 			}
 

--- a/protoc-gen-graphql/spec/field.go
+++ b/protoc-gen-graphql/spec/field.go
@@ -196,10 +196,15 @@ func (f *Field) GraphqlGoType(rootPackage string, isInput bool) string {
 		descriptor.FieldDescriptorProto_TYPE_INT64,
 		descriptor.FieldDescriptorProto_TYPE_SFIXED32,
 		descriptor.FieldDescriptorProto_TYPE_SFIXED64,
+		descriptor.FieldDescriptorProto_TYPE_FIXED32,
+		descriptor.FieldDescriptorProto_TYPE_FIXED64,
+		descriptor.FieldDescriptorProto_TYPE_SINT32,
+		descriptor.FieldDescriptorProto_TYPE_SINT64,
 		descriptor.FieldDescriptorProto_TYPE_UINT32,
 		descriptor.FieldDescriptorProto_TYPE_UINT64:
 		return "graphql.Int"
-	case descriptor.FieldDescriptorProto_TYPE_STRING:
+	case descriptor.FieldDescriptorProto_TYPE_STRING,
+		descriptor.FieldDescriptorProto_TYPE_BYTES:
 		return "graphql.String"
 	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
 		m := f.DependType.(*Message) // nolint: errcheck
@@ -229,6 +234,6 @@ func (f *Field) GraphqlGoType(rootPackage string, isInput bool) string {
 		}
 		return pkgPrefix + PrefixEnum(strings.ReplaceAll(tn, ".", "_"))
 	default:
-		return "interface{}"
+		return "graphql.SkipDirective"
 	}
 }

--- a/protoc-gen-graphql/spec/file.go
+++ b/protoc-gen-graphql/spec/file.go
@@ -8,8 +8,6 @@ import (
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
-var c = `aaaaa ` + "`" + `sint` + "`" + ` foobar `
-
 // File spec wraps FileDescriptorProto
 // and this spec will be passed in all other specs in order to get
 // filename, package name, etc...

--- a/protoc-gen-graphql/spec/file.go
+++ b/protoc-gen-graphql/spec/file.go
@@ -8,6 +8,8 @@ import (
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
+var c = `aaaaa ` + "`" + `sint` + "`" + ` foobar `
+
 // File spec wraps FileDescriptorProto
 // and this spec will be passed in all other specs in order to get
 // filename, package name, etc...
@@ -97,7 +99,7 @@ func (f *File) getComment(paths []int) string {
 	}
 
 	if v, ok := f.comments[b.String()]; ok {
-		return strings.TrimSpace(v)
+		return strings.ReplaceAll(strings.TrimSpace(v), "`", "`+\"`\"+`")
 	}
 	return ""
 }

--- a/protoc-gen-graphql/template.go
+++ b/protoc-gen-graphql/template.go
@@ -5,13 +5,13 @@ var goTemplate = `
 package {{ .RootPackage.Name }}
 
 import (
+{{- if .Services }}
 	"context"
 
-	"github.com/graphql-go/graphql"
-{{- if .Services }}
 	"github.com/ysugimoto/grpc-graphql-gateway/runtime"
 	"google.golang.org/grpc"
 {{- end }}
+	"github.com/graphql-go/graphql"
 
 {{- range .Packages }}
 	{{ if .Path }}{{ .Name }} "{{ .Path }}"{{ end }}


### PR DESCRIPTION
This PR fixes:

- Enable to compile even if back-tick character contains in a comment section
- Stop recursive detection in order to prevent an infinite loop 
- Default type as `graphql.SkipDirective`