### PR TITLE
support custom package name

### DIFF
--- a/example/greeter/Makefile
+++ b/example/greeter/Makefile
@@ -1,9 +1,17 @@
 .PHONY: build
 
 build:
+	cd ../../ && make
 	protoc \
 	  -I. \
+		-I./grpc-gateway \
 		--plugin=../../dist/protoc-gen-graphql \
-	  --go_out=plugins=grpc:./greeter \
-		--graphql_out=verbose:./greeter \
-	  greeter.proto
+	  --go_out=plugins=grpc:./gateway \
+		--graphql_out=verbose:./gateway \
+	  ./grpc-gateway/google/api/annotations.proto
+	#protoc \
+	#  -I. \
+	#	--plugin=../../dist/protoc-gen-graphql \
+	#  --go_out=plugins=grpc:./greeter \
+	#	--graphql_out=verbose:./greeter \
+	#  greeter.proto

--- a/protoc-gen-graphql/spec/package.go
+++ b/protoc-gen-graphql/spec/package.go
@@ -26,8 +26,14 @@ type Package struct {
 func NewPackage(g PackageGetter) *Package {
 	p := &Package{}
 	if pkg := g.GoPackage(); pkg != "" {
-		p.Name = filepath.Base(pkg)
-		p.Path = pkg
+		// Support custom package definitions like example.com/path/to/package:packageName
+		if index := strings.Index(pkg, ";"); index > -1 {
+			p.Name = pkg[index+1:]
+			p.Path = pkg[0:index]
+		} else {
+			p.Name = filepath.Base(pkg)
+			p.Path = pkg
+		}
 	} else if pkg := g.Package(); pkg != "" {
 		p.Name = pkg
 	} else {
@@ -39,5 +45,18 @@ func NewPackage(g PackageGetter) *Package {
 	}
 
 	p.CamelName = strcase.ToCamel(p.Name)
+	return p
+}
+
+func NewGoPackageFromString(pkg string) *Package {
+	p := &Package{}
+	// Support custom package definitions like example.com/path/to/package:packageName
+	if index := strings.Index(pkg, ";"); index > -1 {
+		p.Name = pkg[index+1:]
+		p.Path = pkg[0:index]
+	} else {
+		p.Name = filepath.Base(pkg)
+		p.Path = pkg
+	}
 	return p
 }


### PR DESCRIPTION
This PR adds:

#### Support custom package name 

Some package declares go package with:

```
option go_package = "some.example.com/path/to/pakcage;custom_package";
```

Then this package should compile as:

- import path: `some.example.com/path/to/pakcage`
- package name: `custom_package`
