### PR TITLE
support exclude option

### DIFF
--- a/example/greeter/Makefile
+++ b/example/greeter/Makefile
@@ -1,17 +1,9 @@
 .PHONY: build
 
 build:
-	cd ../../ && make
 	protoc \
 	  -I. \
-		-I./grpc-gateway \
 		--plugin=../../dist/protoc-gen-graphql \
-	  --go_out=plugins=grpc:./gateway \
-		--graphql_out=verbose:./gateway \
-	  ./grpc-gateway/google/api/annotations.proto
-	#protoc \
-	#  -I. \
-	#	--plugin=../../dist/protoc-gen-graphql \
-	#  --go_out=plugins=grpc:./greeter \
-	#	--graphql_out=verbose:./greeter \
-	#  greeter.proto
+	  --go_out=plugins=grpc:./greeter \
+		--graphql_out=verbose:./greeter \
+	  greeter.proto

--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -79,6 +79,7 @@ func (g *Generator) Generate(tmpl string, fs []string) ([]*plugin.CodeGeneratorR
 			if f.Filename() != v {
 				continue
 			}
+
 			s, ok := services[f.Package()]
 			if !ok {
 				continue

--- a/protoc-gen-graphql/main.go
+++ b/protoc-gen-graphql/main.go
@@ -60,10 +60,18 @@ func main() {
 	}
 
 	g := generator.New(files, args)
-	genFiles, err := g.Generate(goTemplate, req.GetFileToGenerate())
-	if err != nil {
-		genError = err
-		return
+	var ftg []string
+	for _, f := range req.GetFileToGenerate() {
+		if !args.IsExclude(f) {
+			ftg = append(ftg, f)
+		}
 	}
-	resp.File = append(resp.File, genFiles...)
+	if len(ftg) > 0 {
+		genFiles, err := g.Generate(goTemplate, ftg)
+		if err != nil {
+			genError = err
+			return
+		}
+		resp.File = append(resp.File, genFiles...)
+	}
 }

--- a/protoc-gen-graphql/spec/params.go
+++ b/protoc-gen-graphql/spec/params.go
@@ -2,17 +2,21 @@ package spec
 
 import (
 	"errors"
+	"regexp"
 	"strings"
 )
 
 // Params spec have plugin parameters
 type Params struct {
 	QueryOut string
+	Excludes []*regexp.Regexp
 	Verbose  bool
 }
 
 func NewParams(p string) (*Params, error) {
-	params := &Params{}
+	params := &Params{
+		Excludes: []*regexp.Regexp{},
+	}
 	if p == "" {
 		return params, nil
 	}
@@ -27,9 +31,27 @@ func NewParams(p string) (*Params, error) {
 				return nil, errors.New("argument " + kv[0] + " must have value")
 			}
 			params.QueryOut = kv[1]
+		case "exclude":
+			if len(kv) == 1 {
+				return nil, errors.New("argument " + kv[0] + " must have value")
+			}
+			regex, err := regexp.Compile(kv[1])
+			if err != nil {
+				return nil, errors.New("failed to compile regex for exclude argument " + kv[1])
+			}
+			params.Excludes = append(params.Excludes, regex)
 		default:
 			return nil, errors.New("Unacceptable argument " + kv[0] + " provided")
 		}
 	}
 	return params, nil
+}
+
+func (p *Params) IsExclude(pkg string) bool {
+	for _, r := range p.Excludes {
+		if r.MatchString(pkg) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR fixes:

- adding exclude option. if a user supplies `exclude=[regex]`, then this plugin prevent to generate

mainly this option avoids compiling error for other packages unexpectedly.