### PR TITLE
Change middleware interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 ![image](https://raw.githubusercontent.com/ysugimoto/grpc-graphql-gateway/master/misc/grpc-graphql-gateway.png)
 
+## Change Log
+
+### v0.9.1
+
+#### Changed middleware fucntion type
+
+No longer passing `context.Context` to first argument of `MiddlewareFunc`. this is because we need to pass custom metadata to gRPC.
+If you are already using your onw middleware, plase change its interface. To access current context, get from `http.Request` by calling `r.Context()`.
+
 ## Motivation
 
 On API development, frequently we choose some IDL, in order to manage API definitions from a file.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 #### Changed middleware fucntion type
 
-No longer passing `context.Context` to first argument of `MiddlewareFunc`. this is because we need to pass custom metadata to gRPC.
-If you are already using your onw middleware, plase change its interface. To access current context, get from `http.Request` by calling `r.Context()`.
+On MiddlewareFunc, you need to return `context.Context` as first return value. this is because we need to make custom metadata to gRPC on middleware process.
+If you are already using your onw middleware, plase change its interface. see https://github.com/ysugimoto/grpc-graphql-gateway/pull/10
 
 ## Motivation
 

--- a/runtime/middlewares.go
+++ b/runtime/middlewares.go
@@ -1,16 +1,17 @@
 package runtime
 
 import (
+	"context"
 	"net/http"
 )
 
 // Cors is middelware function to provide CORS headers to response headers
 func Cors() MiddlewareFunc {
-	return func(w http.ResponseWriter, r *http.Request) error {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) (context.Context, error) {
 		w.Header().Set("Access-Control-Allow-Origin", r.URL.Host)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		w.Header().Set("Access-Control-Max-Age", "1728000")
-		return nil
+		return ctx, nil
 	}
 }

--- a/runtime/middlewares.go
+++ b/runtime/middlewares.go
@@ -1,13 +1,12 @@
 package runtime
 
 import (
-	"context"
 	"net/http"
 )
 
 // Cors is middelware function to provide CORS headers to response headers
 func Cors() MiddlewareFunc {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
 		w.Header().Set("Access-Control-Allow-Origin", r.URL.Host)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -14,7 +14,7 @@ import (
 
 type (
 	// MiddlewareFunc type definition
-	MiddlewareFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+	MiddlewareFunc func(w http.ResponseWriter, r *http.Request) error
 
 	// Custom error handler which is called on graphql result has an error
 	GraphqlErrorHandler func(errs gqlerrors.FormattedErrors)
@@ -91,14 +91,13 @@ func (s *ServeMux) Use(ms ...MiddlewareFunc) *ServeMux {
 
 // ServeHTTP implements http.Handler
 func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
 	for _, m := range s.middlewares {
-		if err := m(ctx, w, r); err != nil {
+		if err := m(w, r); err != nil {
 			http.Error(w, "middleware error occurred: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}
+	ctx := r.Context()
 
 	queries := graphql.Fields{}
 	mutations := graphql.Fields{}

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -14,7 +14,7 @@ import (
 
 type (
 	// MiddlewareFunc type definition
-	MiddlewareFunc func(w http.ResponseWriter, r *http.Request) error
+	MiddlewareFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) (context.Context, error)
 
 	// Custom error handler which is called on graphql result has an error
 	GraphqlErrorHandler func(errs gqlerrors.FormattedErrors)
@@ -91,13 +91,15 @@ func (s *ServeMux) Use(ms ...MiddlewareFunc) *ServeMux {
 
 // ServeHTTP implements http.Handler
 func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	for _, m := range s.middlewares {
-		if err := m(w, r); err != nil {
+		var err error
+		ctx, err = m(ctx, w, r)
+		if err != nil {
 			http.Error(w, "middleware error occurred: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}
-	ctx := r.Context()
 
 	queries := graphql.Fields{}
 	mutations := graphql.Fields{}


### PR DESCRIPTION
This PR changes the` MiddlewareFunc` interface that may return multiple values as context and error.

Before:
```go
type MiddlewareFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) error
```

After:
```go
type MiddlewareFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request) (context.Context, error)	
```

This change aims to pass metadata from an incoming HTTP request, so you can set custom metadata as follows:

```go
import (
  "context"
  "net/http"
  "google.golang.org/grpc/metadata"
)

func CustomMetadataMiddleware(ctx context.Context, w http.ResponseWriter, r *http.Request) (context.Context, error) {
  md := metadata.Pairs("foo", "bar")
  return metadata.NewIncomingContext(ctx, md), nil
}
```

Then on gRPC handler, you can access via `metadata.FromIncomingContext(ctx)`.