### PR TITLE
Modify type order on field type generation 

### DIFF
--- a/protoc-gen-graphql/spec/field.go
+++ b/protoc-gen-graphql/spec/field.go
@@ -80,11 +80,11 @@ func (f *Field) IsRepeated() bool {
 func (f *Field) FieldType(rootPackage string) string {
 	pkg := NewGoPackageFromString(rootPackage)
 	fieldType := f.GraphqlGoType(pkg.Name, false)
-	if f.IsRepeated() {
-		fieldType = "graphql.NewList(" + fieldType + ")"
-	}
 	if f.IsRequired() {
 		fieldType = "graphql.NewNonNull(" + fieldType + ")"
+	}
+	if f.IsRepeated() {
+		fieldType = "graphql.NewList(" + fieldType + ")"
 	}
 	return fieldType
 }
@@ -92,11 +92,11 @@ func (f *Field) FieldType(rootPackage string) string {
 func (f *Field) FieldTypeInput(rootPackage string) string {
 	pkg := NewGoPackageFromString(rootPackage)
 	fieldType := f.GraphqlGoType(pkg.Name, true)
-	if f.IsRepeated() {
-		fieldType = "graphql.NewList(" + fieldType + ")"
-	}
 	if f.IsRequired() {
 		fieldType = "graphql.NewNonNull(" + fieldType + ")"
+	}
+	if f.IsRepeated() {
+		fieldType = "graphql.NewList(" + fieldType + ")"
 	}
 	return fieldType
 }

--- a/protoc-gen-graphql/spec/query.go
+++ b/protoc-gen-graphql/spec/query.go
@@ -96,7 +96,13 @@ func (q *Query) PluckResponse() []*Field {
 func (q *Query) QueryType() string {
 	if q.IsPluckResponse() {
 		field := q.PluckResponse()[0]
-		return field.FieldType(q.GoPackage())
+		typeName := field.FieldType(q.GoPackage())
+		if resp := q.Response(); resp != nil {
+			if resp.GetRequired() {
+				typeName = "graphql.NewNonNull(" + typeName + ")"
+			}
+		}
+		return typeName
 	}
 
 	var pkgPrefix string


### PR DESCRIPTION
Currently, required field type generates as following:

```
message XXX {
  repeated string foo [(graphql.field).required = true];
```

Then graphql schema will be:

```
type XXX {
  foo: [String]!
}
```

But occasionally this is inconvenient, particularly on TypeScript. So we change and it should be:

```
type XXX {
  foo: [String!]
}
```