### PR TITLE
enum: use protobuf enum type for value

### DIFF
--- a/protoc-gen-graphql/template.go
+++ b/protoc-gen-graphql/template.go
@@ -33,7 +33,7 @@ var (
 	{{- end }}
 )
 
-{{ range .Enums -}}
+{{ range $enum := .Enums -}}
 func Gql__enum_{{ .Name }}() *graphql.Enum {
 	if gql__enum_{{ .Name }} == nil {
 		gql__enum_{{ .Name }} =  graphql.NewEnum(graphql.EnumConfig{
@@ -44,7 +44,7 @@ func Gql__enum_{{ .Name }}() *graphql.Enum {
 					{{- if .Comment }}
 					Description: ` + "`" + `{{ .Comment }}` + "`" + `,
 					{{- end }}
-					Value: {{ .Number }},
+					Value: {{ $enum.Name }}({{ .Number }}),
 				},
 {{- end }}
 			},


### PR DESCRIPTION
Previously, the Value used in the graphql.EnumValueConfig was just the
protobuf enum value as an untyped constant and was converted to int
implicitly by the Go conversion rules.  This caused the
graphql.EnumValueConfigMap to not be able to lookup and convert to
string the protobuf enum types in return values since the valuesLookup
map is via interface{} and the types differ.  All returned enums in gRPC
calls were converted to null.

This change explicitly casts the numeric enum values to the proper
protobuf enum type in graphql.EnumValueConfig so they are converted
correctly when returned in gRPC messages from the underlying service.