### PR TITLE
Implement google ptypes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ definitions:
              sudo ln -s /usr/local/protoc/bin/protoc /usr/local/bin
              sudo ln -s /usr/local/protoc/include/google `pwd`/include/google
              go get -u github.com/golang/protobuf/protoc-gen-go
-        - run: make all
+        - run: make all tag=${CIRCLE_TAG}
         - persist_to_workspace:
            root: .
            paths:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ example/**/graphql
 example/**/schema.graphql
 example/**/github.com
 example/**/app
+playground

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 .PHONY: command clean
 
 GRAPHQL_CMD=protoc-gen-graphql
+VERSION=$(or ${tag}, dev)
 
 command: plugin clean
-	cd ${GRAPHQL_CMD} && go build -o ../dist/${GRAPHQL_CMD}
+	cd ${GRAPHQL_CMD} && \
+		go build \
+			-ldflags "-X main.version=${VERSION}" \
+			-o ../dist/${GRAPHQL_CMD}
 
 lint:
 	golangci-lint run
@@ -31,5 +35,5 @@ clean:
 	rm -rf ./dist/*
 
 all: clean build
-	cd ${GRAPHQL_CMD} && GOOS=darwin GOARCH=amd64 go build -o ../dist/${GRAPHQL_CMD}.darwin
-	cd ${GRAPHQL_CMD} && GOOS=linux GOARCH=amd64 go build -o ../dist/${GRAPHQL_CMD}.linux
+	cd ${GRAPHQL_CMD} && GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o ../dist/${GRAPHQL_CMD}.darwin
+	cd ${GRAPHQL_CMD} && GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o ../dist/${GRAPHQL_CMD}.linux

--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -108,7 +108,6 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 	var types, inputs, interfaces []*spec.Message
 	var enums []*spec.Enum
 	var packages []*spec.Package
-	// stack := make(map[string]struct{})
 
 	for _, m := range g.messages {
 		// skip empty field message, otherwise graphql-go raise error
@@ -120,10 +119,8 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 				types = append(types, m)
 			} else if spec.IsGooglePackage(m) {
 				packages = append(packages, spec.NewGooglePackage(m))
-				// stack[m.Package()] = struct{}{}
-			} else { // else if _, ok := stack[m.Package()]; !ok {
+			} else {
 				packages = append(packages, spec.NewPackage(m))
-				// stack[m.Package()] = struct{}{}
 			}
 		}
 		if m.IsDepended(spec.DependTypeInput, file.Package()) {
@@ -179,7 +176,7 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 		if e.IsDepended(spec.DependTypeEnum, file.Package()) {
 			if file.Package() == e.Package() || spec.IsGooglePackage(e) {
 				enums = append(enums, e)
-			} else { // if _, ok := stack[e.Package()]; !ok {
+			} else {
 				packages = append(packages, spec.NewPackage(e))
 			}
 		}

--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -116,8 +116,11 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 			continue
 		}
 		if m.IsDepended(spec.DependTypeMessage, file.Package()) {
-			if file.Package() == m.Package() || spec.IsGooglePackage(m) {
+			if file.Package() == m.Package() {
 				types = append(types, m)
+			} else if spec.IsGooglePackage(m) {
+				packages = append(packages, spec.NewGooglePackage(m))
+				stack[m.Package()] = struct{}{}
 			} else if _, ok := stack[m.Package()]; !ok {
 				packages = append(packages, spec.NewPackage(m))
 				stack[m.Package()] = struct{}{}

--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -108,7 +108,7 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 	var types, inputs, interfaces []*spec.Message
 	var enums []*spec.Enum
 	var packages []*spec.Package
-	stack := make(map[string]struct{})
+	// stack := make(map[string]struct{})
 
 	for _, m := range g.messages {
 		// skip empty field message, otherwise graphql-go raise error
@@ -120,10 +120,10 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 				types = append(types, m)
 			} else if spec.IsGooglePackage(m) {
 				packages = append(packages, spec.NewGooglePackage(m))
-				stack[m.Package()] = struct{}{}
-			} else if _, ok := stack[m.Package()]; !ok {
+				// stack[m.Package()] = struct{}{}
+			} else { // else if _, ok := stack[m.Package()]; !ok {
 				packages = append(packages, spec.NewPackage(m))
-				stack[m.Package()] = struct{}{}
+				// stack[m.Package()] = struct{}{}
 			}
 		}
 		if m.IsDepended(spec.DependTypeInput, file.Package()) {
@@ -131,6 +131,43 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 		}
 		if m.IsDepended(spec.DependTypeInterface, file.Package()) {
 			interfaces = append(interfaces, m)
+		}
+	}
+
+	for _, s := range services {
+		for _, q := range s.Queries {
+			input, output := q.Input, q.Output
+			if input.Package() != file.Package() {
+				if spec.IsGooglePackage(input) {
+					packages = append(packages, spec.NewGooglePackage(input))
+				} else {
+					packages = append(packages, spec.NewPackage(input))
+				}
+			}
+			if output.Package() != file.Package() {
+				if spec.IsGooglePackage(output) {
+					packages = append(packages, spec.NewGooglePackage(output))
+				} else {
+					packages = append(packages, spec.NewPackage(output))
+				}
+			}
+		}
+		for _, m := range s.Mutations {
+			input, output := m.Input, m.Output
+			if input.Package() != file.Package() {
+				if spec.IsGooglePackage(input) {
+					packages = append(packages, spec.NewGooglePackage(input))
+				} else {
+					packages = append(packages, spec.NewPackage(input))
+				}
+			}
+			if output.Package() != file.Package() {
+				if spec.IsGooglePackage(output) {
+					packages = append(packages, spec.NewGooglePackage(output))
+				} else {
+					packages = append(packages, spec.NewPackage(output))
+				}
+			}
 		}
 	}
 
@@ -142,16 +179,26 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 		if e.IsDepended(spec.DependTypeEnum, file.Package()) {
 			if file.Package() == e.Package() || spec.IsGooglePackage(e) {
 				enums = append(enums, e)
-			} else if _, ok := stack[e.Package()]; !ok {
+			} else { // if _, ok := stack[e.Package()]; !ok {
 				packages = append(packages, spec.NewPackage(e))
-				stack[e.Package()] = struct{}{}
 			}
 		}
 	}
 
+	// drop duplicate packages
+	uniquePackages := make([]*spec.Package, 0)
+	stack := make(map[string]struct{})
+	for _, p := range packages {
+		if _, ok := stack[p.Path]; ok {
+			continue
+		}
+		uniquePackages = append(uniquePackages, p)
+		stack[p.Path] = struct{}{}
+	}
+
 	// Sort by name to avoid to appear some diff on each generation
-	sort.Slice(packages, func(i, j int) bool {
-		return packages[i].Name > packages[j].Name
+	sort.Slice(uniquePackages, func(i, j int) bool {
+		return uniquePackages[i].Name > uniquePackages[j].Name
 	})
 	sort.Slice(types, func(i, j int) bool {
 		return types[i].Name() > types[j].Name()
@@ -172,7 +219,7 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 	root := spec.NewPackage(file)
 	t := &Template{
 		RootPackage: root,
-		Packages:    packages,
+		Packages:    uniquePackages,
 		Types:       types,
 		Enums:       enums,
 		Inputs:      inputs,

--- a/protoc-gen-graphql/main.go
+++ b/protoc-gen-graphql/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"io"
 	"log"
 	"os"
 
@@ -12,7 +14,16 @@ import (
 	"github.com/ysugimoto/grpc-graphql-gateway/protoc-gen-graphql/spec"
 )
 
+var version = "dev"
+var printVersion = flag.Bool("v", false, "show binary version")
+
 func main() {
+	flag.Parse()
+	if *printVersion {
+		io.WriteString(os.Stdout, version)
+		os.Exit(0)
+	}
+
 	var genError error
 
 	resp := &plugin.CodeGeneratorResponse{}

--- a/protoc-gen-graphql/spec/field.go
+++ b/protoc-gen-graphql/spec/field.go
@@ -14,6 +14,7 @@ import (
 var supportedPtypes = []string{
 	"timestamp",
 	"wrappers",
+	"empty",
 }
 
 func mustImplementedPtypes(ptype string) {

--- a/protoc-gen-graphql/spec/field.go
+++ b/protoc-gen-graphql/spec/field.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -48,7 +49,7 @@ func NewField(
 }
 
 func (f *Field) Comment() string {
-	if strings.HasPrefix(f.Package(), "google.protobuf") {
+	if IsGooglePackage(f) {
 		return ""
 	}
 	return f.File.getComment(f.paths)
@@ -229,9 +230,14 @@ func (f *Field) GraphqlGoType(rootPackage string, isInput bool) string {
 		}
 		var pkgPrefix string
 		pkg := NewPackage(m)
-		if pkg.Name != rootPackage {
-			if !IsGooglePackage(m) {
-				pkgPrefix = pkg.Name + "."
+		// Case message is nested, also includes map_entry
+		if rootPackage != "." {
+			if pkg.Name != rootPackage {
+				if IsGooglePackage(m) {
+					pkgPrefix = strings.ToLower(filepath.Base(m.GoPackage())) + "."
+				} else {
+					pkgPrefix = pkg.Name + "."
+				}
 			}
 		}
 		return pkgPrefix + PrefixType(strings.ReplaceAll(tn, ".", "_"))

--- a/protoc-gen-graphql/spec/file.go
+++ b/protoc-gen-graphql/spec/file.go
@@ -56,9 +56,13 @@ func (f *File) Enums() []*Enum {
 }
 
 func (f *File) messagesRecursive(d *descriptor.DescriptorProto, prefix []string, paths ...int) []*Message {
-	messages := []*Message{
-		NewMessage(d, f, prefix, f.isCamel, paths...),
+	m := NewMessage(d, f, prefix, f.isCamel, paths...)
+
+	// If message is map_entry, assign all fields as "required"
+	if opt := d.GetOptions(); opt != nil && opt.GetMapEntry() {
+		m.setRequiredFields()
 	}
+	messages := []*Message{m}
 
 	prefix = append(prefix, d.GetName())
 	for i, m := range d.GetNestedType() {

--- a/protoc-gen-graphql/spec/message.go
+++ b/protoc-gen-graphql/spec/message.go
@@ -58,7 +58,7 @@ func (m *Message) TypeFields() []*Field {
 }
 
 func (m *Message) Comment() string {
-	if strings.HasPrefix(m.Package(), "google.protobuf") {
+	if IsGooglePackage(m) {
 		return ""
 	}
 	return m.File.getComment(m.paths)

--- a/protoc-gen-graphql/spec/message.go
+++ b/protoc-gen-graphql/spec/message.go
@@ -50,6 +50,12 @@ func (m *Message) Fields() []*Field {
 	return m.fields
 }
 
+func (m *Message) setRequiredFields() {
+	for _, f := range m.fields {
+		f.setRequiredField()
+	}
+}
+
 func (m *Message) TypeFields() []*Field {
 	if m.PluckFields == nil {
 		return m.Fields()

--- a/protoc-gen-graphql/spec/package.go
+++ b/protoc-gen-graphql/spec/package.go
@@ -48,6 +48,16 @@ func NewPackage(g PackageGetter) *Package {
 	return p
 }
 
+func NewGooglePackage(m PackageGetter) *Package {
+	name := filepath.Base(m.GoPackage())
+
+	return &Package{
+		Name:      strings.ToLower(name),
+		CamelName: strcase.ToCamel(name),
+		Path:      "github.com/ysugimoto/grpc-graphql-gateway/ptypes/" + strings.ToLower(name),
+	}
+}
+
 func NewGoPackageFromString(pkg string) *Package {
 	p := &Package{}
 	// Support custom package definitions like example.com/path/to/package:packageName

--- a/protoc-gen-graphql/spec/package.go
+++ b/protoc-gen-graphql/spec/package.go
@@ -52,7 +52,7 @@ func NewGooglePackage(m PackageGetter) *Package {
 	name := filepath.Base(m.GoPackage())
 
 	return &Package{
-		Name:      strings.ToLower(name),
+		Name:      "gql_ptypes_" + strings.ToLower(name),
 		CamelName: strcase.ToCamel(name),
 		Path:      "github.com/ysugimoto/grpc-graphql-gateway/ptypes/" + strings.ToLower(name),
 	}

--- a/protoc-gen-graphql/spec/query.go
+++ b/protoc-gen-graphql/spec/query.go
@@ -103,20 +103,23 @@ func (q *Query) PluckResponse() []*Field {
 func (q *Query) QueryType() string {
 	if q.IsPluckResponse() {
 		field := q.PluckResponse()[0]
-		typeName := field.FieldType(q.GoPackage())
-		if resp := q.Response(); resp != nil {
-			if resp.GetRequired() {
-				typeName = "graphql.NewNonNull(" + typeName + ")"
-			}
-		}
-		return typeName
+		return field.FieldType(q.GoPackage())
 	}
 
 	var pkgPrefix string
 	if q.GoPackage() != q.Output.GoPackage() {
-		pkgPrefix = filepath.Base(q.GoPackage())
-		if pkgPrefix != mainPackage {
-			pkgPrefix += "."
+		if IsGooglePackage(q.Output) {
+			name := strings.ToLower(filepath.Base(q.Output.GoPackage()))
+			mustImplementedPtypes(name)
+			pkgPrefix = "gql_ptypes_" + name + "."
+		} else {
+			pkgPrefix = filepath.Base(q.GoPackage())
+			if index := strings.Index(pkgPrefix, ";"); index > -1 {
+				pkgPrefix = pkgPrefix[index+1:]
+			}
+			if pkgPrefix != mainPackage {
+				pkgPrefix += "."
+			}
 		}
 	}
 

--- a/ptypes/empty/empty.go
+++ b/ptypes/empty/empty.go
@@ -1,0 +1,38 @@
+package timestamp
+
+import (
+	"github.com/graphql-go/graphql"
+)
+
+var (
+	gql__type_Empty  *graphql.Object
+	gql__input_Empty *graphql.InputObject
+)
+
+func Gql__type_Empty() *graphql.Object {
+	if gql__type_Empty == nil {
+		gql__type_Empty = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Empty",
+			Fields: graphql.Fields{
+				"_": &graphql.Field{
+					Type: graphql.Boolean,
+				},
+			},
+		})
+	}
+	return gql__type_Empty
+}
+
+func Gql__input_Empty() *graphql.InputObject {
+	if gql__input_Empty == nil {
+		gql__input_Empty = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Empty",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"_": &graphql.InputObjectFieldConfig{
+					Type: graphql.Boolean,
+				},
+			},
+		})
+	}
+	return gql__input_Empty
+}

--- a/ptypes/timestamp/timestamp.go
+++ b/ptypes/timestamp/timestamp.go
@@ -1,0 +1,44 @@
+package timestamp
+
+import (
+	"github.com/graphql-go/graphql"
+)
+
+var (
+	gql__type_Timestamp  *graphql.Object
+	gql__input_Timestamp *graphql.InputObject
+)
+
+func Gql__type_Timestamp() *graphql.Object {
+	if gql__type_Timestamp == nil {
+		gql__type_Timestamp = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Timestamp",
+			Fields: graphql.Fields{
+				"seconds": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+				"nanos": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__type_Timestamp
+}
+
+func Gql__input_Timestamp() *graphql.InputObject {
+	if gql__input_Timestamp == nil {
+		gql__input_Timestamp = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Timestamp",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"seconds": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+				"nanos": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__input_Timestamp
+}

--- a/ptypes/wrappers/wrappers.go
+++ b/ptypes/wrappers/wrappers.go
@@ -1,0 +1,248 @@
+package wrappers
+
+import (
+	"github.com/graphql-go/graphql"
+)
+
+var (
+	gql__type_DoubleValue  *graphql.Object
+	gql__type_FloatValue   *graphql.Object
+	gql__type_Int64Value   *graphql.Object
+	gql__type_Uint64Value  *graphql.Object
+	gql__type_Int32Value   *graphql.Object
+	gql__type_Uint32Value  *graphql.Object
+	gql__type_BoolValue    *graphql.Object
+	gql__type_StringValue  *graphql.Object
+	gql__input_DoubleValue *graphql.InputObject
+	gql__input_FloatValue  *graphql.InputObject
+	gql__input_Int64Value  *graphql.InputObject
+	gql__input_Uint64Value *graphql.InputObject
+	gql__input_Int32Value  *graphql.InputObject
+	gql__input_Uint32Value *graphql.InputObject
+	gql__input_BoolValue   *graphql.InputObject
+	gql__input_StringValue *graphql.InputObject
+)
+
+func Gql__type_DoubleValue() *graphql.Object {
+	if gql__type_DoubleValue == nil {
+		gql__type_DoubleValue = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Wrappers_DoubleValue",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Float),
+				},
+			},
+		})
+	}
+	return gql__type_DoubleValue
+}
+
+func Gql__type_FloatValue() *graphql.Object {
+	if gql__type_FloatValue == nil {
+		gql__type_FloatValue = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Wrappers_FloatValue",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Float),
+				},
+			},
+		})
+	}
+	return gql__type_FloatValue
+}
+
+func Gql__type_Int64Value() *graphql.Object {
+	if gql__type_Int64Value == nil {
+		gql__type_Int64Value = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Wrappers_Int64Value",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__type_Int64Value
+}
+
+func Gql__type_Uint64Value() *graphql.Object {
+	if gql__type_Uint64Value == nil {
+		gql__type_Uint64Value = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Wrappers_Uint64Value",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__type_Uint64Value
+}
+
+func Gql__type_Int32Value() *graphql.Object {
+	if gql__type_Int32Value == nil {
+		gql__type_Int32Value = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Wrappers_Int32Value",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__type_Int32Value
+}
+
+func Gql__type_Uint32Value() *graphql.Object {
+	if gql__type_Uint32Value == nil {
+		gql__type_Uint64Value = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Wrappers_Uint32Value",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__type_Uint32Value
+}
+
+func Gql__type_BoolValue() *graphql.Object {
+	if gql__type_BoolValue == nil {
+		gql__type_BoolValue = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Wrappers_BoolValue",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.Boolean),
+				},
+			},
+		})
+	}
+	return gql__type_BoolValue
+}
+
+func Gql__type_StringValue() *graphql.Object {
+	if gql__type_StringValue == nil {
+		gql__type_BoolValue = graphql.NewObject(graphql.ObjectConfig{
+			Name: "Google_type_Wrappers_StringValue",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.String),
+				},
+			},
+		})
+	}
+	return gql__type_StringValue
+}
+
+func Gql__input_DoubleValue() *graphql.InputObject {
+	if gql__input_DoubleValue == nil {
+		gql__input_DoubleValue = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Wrappers_DoubleValue",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Float),
+				},
+			},
+		})
+	}
+	return gql__input_DoubleValue
+}
+
+func Gql__input_FloatValue() *graphql.InputObject {
+	if gql__input_FloatValue == nil {
+		gql__input_FloatValue = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Wrappers_FloatValue",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Float),
+				},
+			},
+		})
+	}
+	return gql__input_FloatValue
+}
+
+func Gql__input_Int64Value() *graphql.InputObject {
+	if gql__input_Int64Value == nil {
+		gql__input_Int64Value = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Wrappers_Int64Value",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__input_Int64Value
+}
+
+func Gql__input_Uint64Value() *graphql.InputObject {
+	if gql__input_Uint64Value == nil {
+		gql__input_Uint64Value = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Wrappers_Uint64Value",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__input_Uint64Value
+}
+
+func Gql__input_Int32Value() *graphql.InputObject {
+	if gql__input_Int32Value == nil {
+		gql__input_Int32Value = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Wrappers_Int32Value",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__input_Int32Value
+}
+
+func Gql__input_Uint32Value() *graphql.InputObject {
+	if gql__input_Uint32Value == nil {
+		gql__input_Uint32Value = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Wrappers_Uint32Value",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Int),
+				},
+			},
+		})
+	}
+	return gql__input_Uint32Value
+}
+
+func Gql__input_BoolValue() *graphql.InputObject {
+	if gql__input_BoolValue == nil {
+		gql__input_BoolValue = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Wrappers_BoolValue",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.Boolean),
+				},
+			},
+		})
+	}
+	return gql__input_BoolValue
+}
+
+func Gql__input_StringValue() *graphql.InputObject {
+	if gql__input_StringValue == nil {
+		gql__input_StringValue = graphql.NewInputObject(graphql.InputObjectConfig{
+			Name: "Google_input_Wrappers_StringValue",
+			Fields: graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{
+					Type: graphql.NewNonNull(graphql.String),
+				},
+			},
+		})
+	}
+	return gql__input_StringValue
+}


### PR DESCRIPTION
This PR implements some features.

### partially solves #15 

Implement specific types and provide from this repository:

- add `google.protobuf.Timestamp`
- add `google.protobuf.Wrappers`
- add `google.protobuf.Empty`

Note that we could only support the above types hence if a user imports other types e.g. `google.protobuf.Any` will raise an error. 

And for GraphQL spec, `google.protobuf.Empty` defined empty field like `_: Boolean` because GraphQL raises error when type fields are empty.


### Fix map type in proto3

In proto3, map type can define as `map<string, string>` but PB parse as xxxEntry message. This PR also can use as graphql type with required key and value.

###  Version printing in plugin binary

`protoc-gen-graphql` accepts `-v` option for print build version.

