### PR TITLE
add required sign

### DIFF
--- a/protoc-gen-graphql/template.go
+++ b/protoc-gen-graphql/template.go
@@ -225,7 +225,7 @@ func (x *graphql__resolver_{{ $service.Name }}) GetMutations(conn *grpc.ClientCo
 			Args: graphql.FieldConfigArgument{
 			{{- if .InputName }}
 				"{{ .InputName }}": &graphql.ArgumentConfig{
-					Type: Gql__input_{{ .Input.TypeName }}(),
+					Type: graphql.NewNonNull(Gql__input_{{ .Input.TypeName }}()),
 				},
 			{{- else }}
 			{{- range .Args }}


### PR DESCRIPTION
Mutation input object must be required so we always add `graphql.NewNonNull()`