### PR TITLE
fix ridiculous bug on wrappers type

### DIFF
--- a/ptypes/wrappers/wrappers.go
+++ b/ptypes/wrappers/wrappers.go
@@ -123,7 +123,7 @@ func Gql__type_BoolValue() *graphql.Object {
 
 func Gql__type_StringValue() *graphql.Object {
 	if gql__type_StringValue == nil {
-		gql__type_BoolValue = graphql.NewObject(graphql.ObjectConfig{
+		gql__type_StringValue = graphql.NewObject(graphql.ObjectConfig{
 			Name: "Google_type_Wrappers_StringValue",
 			Fields: graphql.Fields{
 				"value": &graphql.Field{


### PR DESCRIPTION
#related #15 

This PR fixes POOR bug of us, simply typo the variable name so if the user uses `StringValue` then it causes segmentation fault due to null pointer.