### PR TITLE
fix ptypes generation on input type

### DIFF
--- a/protoc-gen-graphql/spec/field.go
+++ b/protoc-gen-graphql/spec/field.go
@@ -267,10 +267,13 @@ func (f *Field) GraphqlGoType(rootPackage string, isInput bool) string {
 			return PrefixInterface(strings.ReplaceAll(tn, ".", "_"))
 		}
 		if isInput {
-			if IsGooglePackage(m) {
-				return PrefixPtypesInput(strings.ReplaceAll(tn, ".", "_"))
+			if !IsGooglePackage(m) {
+				return PrefixInput(strings.ReplaceAll(tn, ".", "_"))
 			}
-			return PrefixInput(strings.ReplaceAll(tn, ".", "_"))
+			// Case google.protobuf.XXX
+			name := strings.ToLower(filepath.Base(m.GoPackage()))
+			mustImplementedPtypes(name)
+			return "gql_ptypes_" + name + "." + PrefixInput(strings.ReplaceAll(tn, ".", "_"))
 		}
 		var pkgPrefix string
 		pkg := NewPackage(m)
@@ -281,8 +284,7 @@ func (f *Field) GraphqlGoType(rootPackage string, isInput bool) string {
 		} else if rootPackage != "." {
 			// Case message is nested, also includes map_entry
 			if pkg.Name != rootPackage {
-				if IsGooglePackage(m) {
-				} else {
+				if !IsGooglePackage(m) {
 					pkgPrefix = pkg.Name + "."
 				}
 			}

--- a/protoc-gen-graphql/spec/prefix.go
+++ b/protoc-gen-graphql/spec/prefix.go
@@ -19,11 +19,6 @@ func PrefixInput(name string) string {
 	return "Gql__input_" + name + "()"
 }
 
-// PrefixPtypes adds prefix to avoid conflicting name
-func PrefixPtypesInput(name string) string {
-	return "gql_ptypes_" + strings.ToLower(name) + ".Gql__input_" + name + "()"
-}
-
 // PrefixInterface adds prefix to avoid conflicting name
 func PrefixInterface(name string) string {
 	return "Gql__interface_" + name + "()"


### PR DESCRIPTION
fixes #28 

This PR fixes code generation for Google's ptypes with input object package resolving.
After this PR, the input of protobuf wrapper type (for example) for input:

```protobuf
message Example {
  google.protobuf.Int32Value id = 1;
}
```

And then the generated code should be:

```go
...
func Gql__input_Exmple() *graphql.InputObject {
	if gql__input_Example == nil {
		gql__input_Example = graphql.NewInputObject(graphql.InputObjectConfig{
			Name: "Echo_Input_Example",
			Fields: graphql.InputObjectConfigFieldMap{
				"id": &graphql.InputObjectFieldConfig{
					Type: gql_ptypes_wrappers.Gql__input_Int32Value(),
				},
				
			},
		})
	}
	return gql__input_Example
}
...
```

