### PR TITLE
also add input dependency

### DIFF
--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -273,6 +273,7 @@ func (g *Generator) analyzeMessage(file *spec.File) error {
 			continue
 		}
 		m.Depend(spec.DependTypeMessage, file.Package())
+		m.Depend(spec.DependTypeInput, file.Package())
 		if err := g.analyzeFields(file.Package(), m, m.Fields(), false, false); err != nil {
 			return err
 		}


### PR DESCRIPTION
Since #30, we have a bit problem that the nested message could not specify the argument list.

```protobuf
syntax = "proto3";

import "graphql.proto";
import "google/protobuf/wrappers.proto";

option go_package = ".;echo";

service Echo {
  // gRPC service information
  option (graphql.service) = {
    host: "localhost:50051"
    insecure: true
  };

  rpc Sample(SampleMessage) returns (SampleMessage) {
    option (graphql.schema) = {
      type: QUERY
      name: "sample"
    };
  }
}
message Member {
  int64 id = 2;
}

message SampleMessage {
  Member member = 1; // could not be assigned in request argument
}
```

To solve them, we can use `FieldTypeInput` always in argument definition but then we also need InputObject in package scope.

This change is just only one line but solves that problem,