### PR TITLE
modify FieldTypeInput for nested query

### DIFF
--- a/protoc-gen-graphql/template.go
+++ b/protoc-gen-graphql/template.go
@@ -106,7 +106,7 @@ func Gql__type_{{ .TypeName }}() *graphql.Object {
 						Args: graphql.FieldConfigArgument{
 						{{- range $query.Args }}
 							"{{ .FieldName }}": &graphql.ArgumentConfig{
-								Type: {{ .FieldType $.RootPackage.Path }},
+								Type: {{ .FieldTypeInput $.RootPackage.Path }},
 								{{- if .Comment }}
 								Description: ` + "`" + `{{ .Comment }}` + "`" + `,
 								{{- end }}


### PR DESCRIPTION
This PR relates #32 , we need to use `FieldTypeInput` for nested resolver.