### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Compile protobuf file with the plugin:
 ```shell
 protoc \
   -I. \
-  --go_out=plugins=grpc:./greeter \
+  --go_out=./greeter \
+  --go-grpc_out=./greeter \
   --graphql_out=./greeter \
   greeter.proto
 ```


### PR DESCRIPTION
plugin format is deprecated, grpc-go is its own protoc plugin now.