### PR TITLE
support paths=source_relative option

### DIFF
--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -242,6 +242,14 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 		return nil, err
 	}
 
+	// If paths=source_relative option is provided, put generated file relatively
+	if g.args.IsSourceRelative() {
+		return &plugin.CodeGeneratorResponse_File{
+			Name:    proto.String(fmt.Sprintf("%s.graphql.go", root.Name)),
+			Content: proto.String(string(out)),
+		}, nil
+	}
+
 	return &plugin.CodeGeneratorResponse_File{
 		Name:    proto.String(fmt.Sprintf("%s/%s.graphql.go", root.Path, root.Name)),
 		Content: proto.String(string(out)),

--- a/protoc-gen-graphql/spec/params.go
+++ b/protoc-gen-graphql/spec/params.go
@@ -6,12 +6,18 @@ import (
 	"strings"
 )
 
+var acceptablePathsValues = map[string]struct{}{
+	"import":          {},
+	"source_relative": {},
+}
+
 // Params spec have plugin parameters
 type Params struct {
 	QueryOut       string
 	Excludes       []*regexp.Regexp
 	Verbose        bool
 	FieldCamelCase bool
+	Paths          string
 }
 
 func NewParams(p string) (*Params, error) {
@@ -43,6 +49,13 @@ func NewParams(p string) (*Params, error) {
 			params.Excludes = append(params.Excludes, regex)
 		case "field_camel":
 			params.FieldCamelCase = true
+		case "paths":
+			if len(kv) == 1 {
+				return nil, errors.New("argument " + kv[0] + " must have value")
+			} else if _, ok := acceptablePathsValues[kv[1]]; !ok {
+				return nil, errors.New("argument " + kv[0] + " value must either of import and source_relative")
+			}
+			params.Paths = kv[1]
 		default:
 			return nil, errors.New("Unacceptable argument " + kv[0] + " provided")
 		}
@@ -57,4 +70,8 @@ func (p *Params) IsExclude(pkg string) bool {
 		}
 	}
 	return false
+}
+
+func (p *Params) IsSourceRelative() bool {
+	return p.Paths == "source_relative"
 }


### PR DESCRIPTION
Fixes #50 

This PR supports the common option of `paths=source_relative`.
`protoc-gen-graphql` supports above option and behaves as same as `protoc-gen-go`.

### Usage

You can provide this option like:

```shell
protoc \
    -Iproto \
    -go_out=. \
    -go-grpc_out=. \
    -go-grpc_opt=paths=source_relative \
    -graphql_out=. \
    -graphql_opt=paths=source:relative \
    example.proto
```

Above command should be placed the same directory of `example.proto`

Documented here: https://developers.google.com/protocol-buffers/docs/reference/go-generated