### PR TITLE
fix protobuf compile error in greeter.proto

### DIFF
--- a/example/greeter/greeter.proto
+++ b/example/greeter/greeter.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "graphql.proto";
 
-option go_package = ".;greeter";
+option go_package = "./;greeter";
 
 service Greeter {
   // gRPC service information


### PR DESCRIPTION
Fix protobuf compile error in below:

```
protoc \
	  -I. \
		-I../../include/graphql \
		--plugin=../../dist/protoc-gen-graphql \
	  --go_out=plugins=grpc:./greeter \
		--graphql_out=verbose:./greeter \
	  greeter.proto
protoc-gen-go: invalid Go import path "." for "greeter.proto"

The import path must contain at least one forward slash ('/') character.

See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.

--go_out: protoc-gen-go: Plugin failed with status code 1.
```