### PR TITLE
Resolve source_relative not respecting subpath proto files

### DIFF
--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -245,13 +245,13 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 	// If paths=source_relative option is provided, put generated file relatively
 	if g.args.IsSourceRelative() {
 		return &plugin.CodeGeneratorResponse_File{
-			Name:    proto.String(fmt.Sprintf("%s.graphql.go", root.Name)),
+			Name:    proto.String(fmt.Sprintf("%s.pb.graphql.go", root.GeneratedFilenamePrefix)),
 			Content: proto.String(string(out)),
 		}, nil
 	}
 
 	return &plugin.CodeGeneratorResponse_File{
-		Name:    proto.String(fmt.Sprintf("%s/%s.graphql.go", root.Path, root.Name)),
+		Name:    proto.String(fmt.Sprintf("%s/%s.pb.graphql.go", root.Path, root.Name)),
 		Content: proto.String(string(out)),
 	}, nil
 }

--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -245,13 +245,13 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 	// If paths=source_relative option is provided, put generated file relatively
 	if g.args.IsSourceRelative() {
 		return &plugin.CodeGeneratorResponse_File{
-			Name:    proto.String(fmt.Sprintf("%s.pb.graphql.go", root.GeneratedFilenamePrefix)),
+			Name:    proto.String(fmt.Sprintf("%s.graphql.go", root.GeneratedFilenamePrefix)),
 			Content: proto.String(string(out)),
 		}, nil
 	}
 
 	return &plugin.CodeGeneratorResponse_File{
-		Name:    proto.String(fmt.Sprintf("%s/%s.pb.graphql.go", root.Path, root.Name)),
+		Name:    proto.String(fmt.Sprintf("%s/%s.graphql.go", root.Path, root.Name)),
 		Content: proto.String(string(out)),
 	}, nil
 }

--- a/protoc-gen-graphql/generator/generator.go
+++ b/protoc-gen-graphql/generator/generator.go
@@ -251,7 +251,7 @@ func (g *Generator) generateFile(file *spec.File, tmpl string, services []*spec.
 	}
 
 	return &plugin.CodeGeneratorResponse_File{
-		Name:    proto.String(fmt.Sprintf("%s/%s.graphql.go", root.Path, root.Name)),
+		Name:    proto.String(fmt.Sprintf("%s/%s.graphql.go", root.Path, root.FileName)),
 		Content: proto.String(string(out)),
 	}, nil
 }

--- a/protoc-gen-graphql/spec/package.go
+++ b/protoc-gen-graphql/spec/package.go
@@ -22,20 +22,31 @@ type Package struct {
 	CamelName               string
 	Path                    string
 	GeneratedFilenamePrefix string
+	FileName                string
 }
 
 func NewPackage(g PackageGetter) *Package {
 	p := &Package{}
-	p.Name = strings.TrimSuffix(filepath.Base(g.Filename()), filepath.Ext(g.Filename()))
 	p.GeneratedFilenamePrefix = strings.TrimSuffix(g.Filename(), filepath.Ext(g.Filename()))
+	p.FileName = filepath.Base(p.GeneratedFilenamePrefix)
 
 	if pkg := g.GoPackage(); pkg != "" {
 		// Support custom package definitions like example.com/path/to/package:packageName
 		if index := strings.Index(pkg, ";"); index > -1 {
+			p.Name = pkg[index+1:]
 			p.Path = pkg[0:index]
 		} else {
+			p.Name = filepath.Base(pkg)
 			p.Path = pkg
 		}
+	} else if pkg := g.Package(); pkg != "" {
+		p.Name = pkg
+	} else {
+		p.Name = strings.ReplaceAll(
+			g.Filename(),
+			filepath.Ext(g.Filename()),
+			"",
+		)
 	}
 
 	p.CamelName = strcase.ToCamel(p.Name)

--- a/protoc-gen-graphql/spec/package.go
+++ b/protoc-gen-graphql/spec/package.go
@@ -18,9 +18,10 @@ type PackageGetter interface {
 }
 
 type Package struct {
-	Name      string
-	CamelName string
-	Path      string
+	Name                    string
+	CamelName               string
+	Path                    string
+	GeneratedFilenamePrefix string
 }
 
 func NewPackage(g PackageGetter) *Package {
@@ -44,6 +45,7 @@ func NewPackage(g PackageGetter) *Package {
 		)
 	}
 
+	p.GeneratedFilenamePrefix = strings.TrimSuffix(g.Filename(), ".proto")
 	p.CamelName = strcase.ToCamel(p.Name)
 	return p
 }

--- a/protoc-gen-graphql/spec/package.go
+++ b/protoc-gen-graphql/spec/package.go
@@ -26,26 +26,18 @@ type Package struct {
 
 func NewPackage(g PackageGetter) *Package {
 	p := &Package{}
+	p.Name = strings.TrimSuffix(filepath.Base(g.Filename()), filepath.Ext(g.Filename()))
+	p.GeneratedFilenamePrefix = strings.TrimSuffix(g.Filename(), filepath.Ext(g.Filename()))
+
 	if pkg := g.GoPackage(); pkg != "" {
 		// Support custom package definitions like example.com/path/to/package:packageName
 		if index := strings.Index(pkg, ";"); index > -1 {
-			p.Name = pkg[index+1:]
 			p.Path = pkg[0:index]
 		} else {
-			p.Name = filepath.Base(pkg)
 			p.Path = pkg
 		}
-	} else if pkg := g.Package(); pkg != "" {
-		p.Name = pkg
-	} else {
-		p.Name = strings.ReplaceAll(
-			g.Filename(),
-			filepath.Ext(g.Filename()),
-			"",
-		)
 	}
 
-	p.GeneratedFilenamePrefix = strings.TrimSuffix(g.Filename(), ".proto")
 	p.CamelName = strcase.ToCamel(p.Name)
 	return p
 }


### PR DESCRIPTION
The `source_relative` option will only generate the resulting `.go` file into the specified out directory. However, when `.proto` files are nested down a path, other protoc plugins will respect the paths and output the files down the same file path. 

Following [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/protoc-gen-grpc-gateway/internal/gengateway/generator.go#L94), they use the `.proto`'s file path as a prefix to the path of the generate `.go` file. 

Additionally, I followed a similar pattern of retrieving the filename prefix to refactor the retrieval of the file name when `source_relative` is not used.